### PR TITLE
Add X (Twitter) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently supported websites:
 - LinkedIn
 - Instagram
 - Facebook
+- X (Twitter)
 
 
 Note that the add-on is in its early phase; please submit a review for any issue or feature request.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,9 @@
   "host_permissions": [
     "*://*.linkedin.com/*",
     "*://*.facebook.com/*",
-    "*://*.instagram.com/*"
+    "*://*.instagram.com/*",
+    "*://*.x.com/*",
+    "*://*.twitter.com/*"
   ],
   "action": {
     "default_popup": "src/popup.html",
@@ -29,7 +31,9 @@
       "matches": [
         "*://*.linkedin.com/*",
         "*://*.facebook.com/*",
-        "*://*.instagram.com/*"
+        "*://*.instagram.com/*",
+        "*://*.x.com/*",
+        "*://*.twitter.com/*"
       ],
       "js": [
         "dist/content.bundle.js"

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status === 'complete' && tab.url) {
         console.log('onComplete');
         // Check if the URL matches the patterns specified in the manifest
-        if (tab.url.match(/.*(linkedin|facebook|instagram|tumblr)\.com.*/)) {
+        if (tab.url.match(/\/\/([^/]+\.)?(linkedin|facebook|instagram|tumblr|twitter|x)\.com\b/)) {
             // Inject content.js as a module
             console.log('executeScript: ' + tab.url);
             browser.scripting.executeScript({

--- a/src/core.js
+++ b/src/core.js
@@ -400,6 +400,42 @@ async function removeInstagramLogin() {
     // log("Removed instagram login banner");
 }
 
+async function removeTwitterLogin() {
+    if (!window.location.href.includes('x.com') && !window.location.href.includes('twitter.com')) return;
+    let wanted = await readLocalStorage('twitterWanted');
+    if (!wanted) return;
+
+    // X freezes each photo/video with the "inert" attribute and lays a "View media"
+    // link over it that opens the login gate when clicked. Remove that overlay and
+    // un-freeze the media so its own controls (video player, gallery "Next" button)
+    // work again, then strip the login-gated links on the media itself so clicking it
+    // no longer opens the popup.
+    for (let inert of document.querySelectorAll('[inert]')) {
+        let parent = inert.parentElement;
+        if (!parent) continue;
+        let overlay = parent.querySelector(':scope > a[href*="/photo/"], :scope > a[href*="/video/"]');
+        if (!overlay) continue;
+        log("Disabled twitter media login gate: " + getAttributes(overlay));
+        overlay.remove();
+        inert.removeAttribute('inert');
+        for (let link of inert.querySelectorAll('a[href*="/photo/"], a[href*="/video/"]')) {
+            link.removeAttribute('href');
+        }
+        incrementSkipCounter();
+    }
+
+    // Bottom "Don't miss what's happening" sign-up banner
+    let banners = document.querySelectorAll('.fixed.bottom-0');
+    for (let banner of banners) {
+        if (banner.querySelector('[href*="/i/jf/onboarding/web"]')) {
+            log("Removed twitter bottom login banner: " + getAttributes(banner));
+            banner.remove();
+            incrementSkipCounter();
+            break;
+        }
+    }
+}
+
 async function removeTumblrLogin() {
     if (!window.location.href.includes('tumblr.com')) return;
     let wanted = await readLocalStorage('tumblrWanted');
@@ -432,6 +468,7 @@ export async function checkForLogins() {
         await removeLinkedinLogin();
         await removeFacebookLogin();
         await removeInstagramLogin();
+        await removeTwitterLogin();
         await removeTumblrLogin();
     }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -160,7 +160,16 @@
           <input type="checkbox" id="tumblrWanted" name="muteWanted">
           <span class="slider round"></span>
         </label>
-      </td>    
+      </td>
+    </tr>
+    <tr>
+      <td align="left"><label for="twitterWanted">X (Twitter)</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="twitterWanted" name="muteWanted">
+          <span class="slider round"></span>
+        </label>
+      </td>
     </tr>
   </table>
   <button class="button" id="restoreDefaults">Restore Defaults</button>

--- a/src/popup.js
+++ b/src/popup.js
@@ -52,5 +52,6 @@ document.addEventListener('DOMContentLoaded', function () {
     setElementAndListener("instagramWanted", "checked");
     setElementAndListener("linkedinWanted", "checked");
     setElementAndListener("tumblrWanted", "checked");
+    setElementAndListener("twitterWanted", "checked");
     document.getElementById("restoreDefaults").addEventListener('click', restoreDefaults);
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,5 +4,6 @@ export const defaultOptions = {
     instagramWanted: true,
     linkedinWanted: true,
     tumblrWanted: false,
+    twitterWanted: true,
 }
 // export const local = browser.storage.local;


### PR DESCRIPTION
Adds x.com / twitter.com support

  - Removes the bottom "Don't miss what's happening" sign-up banner
  - Removes the "View media" overlay so clicking a photo/video no longer opens the login popup
  - Un-freezes X's own media controls (removes the `inert` attribute) so the video player and gallery Next button work
  - Strips the login-gated `/photo/` `/video/` links on media so clicks don't route to the login gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for skipping login prompts and signup overlays on X (Twitter).
  - Added an X (Twitter) option to the “No Login” settings.
  - Enabled X (Twitter) support by default.
  - Updated supported-site documentation and access coverage for X and Twitter domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->